### PR TITLE
Fix typo of config hash

### DIFF
--- a/lib/shouhizei.rb
+++ b/lib/shouhizei.rb
@@ -19,7 +19,7 @@ module Shouhizei
   end
 
   def self.config
-    @@config ||= {ronding: RoundDown}
+    @@config ||= {rounding: RoundDown}
   end
 
   private


### PR DESCRIPTION
I found this typo while fixing #2 .
This typo causes a bug when changing codes as followings.
(In other words, there is no bugs in now)

```diff
  def self.included(price:, date: Date.today)
    included_price = price + price * rate_on(date)
    return included_price.ceil if config[:rounding] == RoundUp
-   included_price.floor
+   included_price.floor if config[:rounding] == RoundDown
  end
```