### PR TITLE
Use AS::TimeWithZone instead of Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,26 +23,39 @@ Or install it yourself as:
 You can get Japanese consumption tax rate like below.
 
 ```ruby
-Shouhizei.rate_on(Date.new(1989, 3, 31))
+Shouhizei.rate_on(Time.zone.local(1989, 3, 31))
  => (0/1)
 
-Shouhizei.rate_on(Date.new(1989, 4, 1))
+Shouhizei.rate_on(Time.zone.local(1989, 4, 1))
  => (3/100)
 
-Shouhizei.rate_on(Date.new(1997, 4, 1))
+Shouhizei.rate_on(Time.zone.local(1997, 4, 1))
  => (1/20)
 
-Shouhizei.rate_on(Date.new(2014, 4, 1))
+Shouhizei.rate_on(Time.zone.local(2014, 4, 1))
  => (2/25)
 
-Shouhizei.rate_on()
+Shouhizei.rate_on # Returns the current consumption tax
  => (2/25)
+```
+
+This considers local timezone and changes to `'Asia/Tokyo'` by using `ActiveSupport::TimeWithZone#in_time_zone` .
+
+```ruby
+> Time.zone = 'Asia/Tokyo'
+=> "Asia/Tokyo"
+> Shouhizei.rate_on(Time.zone.local(1989, 3, 31, 10, 0, 0))
+=> (0/1)
+> Time.zone = 'Hawaii'
+=> "Hawaii"
+> Shouhizei.rate_on(Time.zone.local(1989, 3, 31, 10, 0, 0)) # 1989-04-01 05:00:00 in Japan
+=> (3/100)
 ```
 
 Calculation tax included price.
 Return value class is Integer.
 ```ruby
-Shouhizei.included(price: 100, date: Date.new(2014, 4, 1))
+Shouhizei.included(price: 100, date: Time.zone.local(2014, 4, 1))
  => 108 # return value class is Integer
 ```
 

--- a/lib/shouhizei.rb
+++ b/lib/shouhizei.rb
@@ -1,19 +1,22 @@
 require 'shouhizei/version'
 require 'yaml'
+require 'active_support'
+require 'active_support/core_ext'
 
 module Shouhizei
   RoundUp = 'Up'
   RoundDown = 'Down'
 
-  def self.rate_on(date = Date.today)
+  def self.rate_on(time = Time.current)
+    date = time.in_time_zone('Asia/Tokyo').to_date
     rate_list.reverse_each do |key_date, rate|
       return rate.to_r if date >= key_date
     end
     0.0r
   end
 
-  def self.included(price:, date: Date.today)
-    included_price = price + price * rate_on(date)
+  def self.included(price:, time: Time.current)
+    included_price = price + price * rate_on(time)
     return included_price.ceil if config[:rounding] == RoundUp
     included_price.floor
   end

--- a/shouhizei.gemspec
+++ b/shouhizei.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "timecop", "~> 0.9"
+
+  spec.add_dependency "activesupport", ">= 4.1.0"
 end

--- a/test/shouhizei_test.rb
+++ b/test/shouhizei_test.rb
@@ -3,28 +3,33 @@ require 'timecop'
 
 class ShouhizeiTest < Minitest::Test
   def test_rate_on
-    assert_equal(0.0r,  Shouhizei.rate_on(Date.new(1989, 3, 31)))
-    assert_equal(0.03r, Shouhizei.rate_on(Date.new(1989, 4, 1)))
-    assert_equal(0.03r, Shouhizei.rate_on(Date.new(1997, 3, 31)))
-    assert_equal(0.05r, Shouhizei.rate_on(Date.new(1997, 4, 1)))
-    assert_equal(0.05r, Shouhizei.rate_on(Date.new(2014, 3, 31)))
-    assert_equal(0.08r, Shouhizei.rate_on(Date.new(2014, 4, 1)))
-    assert_equal(0.08r, Shouhizei.rate_on())
+    Time.zone = 'Asia/Tokyo'
+    assert_equal(0.0r,  Shouhizei.rate_on(Time.zone.local(1989, 3, 31)))
+    assert_equal(0.03r, Shouhizei.rate_on(Time.zone.local(1989, 4, 1)))
+    assert_equal(0.03r, Shouhizei.rate_on(Time.zone.local(1997, 3, 31)))
+    assert_equal(0.05r, Shouhizei.rate_on(Time.zone.local(1997, 4, 1)))
+    assert_equal(0.05r, Shouhizei.rate_on(Time.zone.local(2014, 3, 31)))
+    assert_equal(0.08r, Shouhizei.rate_on(Time.zone.local(2014, 4, 1)))
+    assert_equal(0.08r, Shouhizei.rate_on)
+
+    Time.zone = 'Hawaii'
+    assert_equal(0.03r, Shouhizei.rate_on(Time.zone.local(1989, 3, 31, 10, 0, 0)))
   end
 
   def test_price_calculation
-    assert_equal(108, Shouhizei.included(price: 100, date: Date.new(2014, 4, 1)))
+    Time.zone = 'Asia/Tokyo'
+    assert_equal(108, Shouhizei.included(price: 100, time: Time.zone.local(2014, 4, 1)))
 
-    Timecop.freeze(Date.new(2014, 4, 1)) do
+    Timecop.freeze(Time.zone.local(2014, 4, 1)) do
       Shouhizei.config[:rounding] = Shouhizei::RoundUp
       round_up_price = Shouhizei.included(price: 10)
       assert_equal(11, round_up_price)
-      assert_instance_of(Integer, round_up_price)
+      assert_kind_of(Integer, round_up_price)
 
       Shouhizei.config[:rounding] = Shouhizei::RoundDown
       round_down_price = Shouhizei.included(price: 10)
       assert_equal(10, round_down_price)
-      assert_instance_of(Integer, round_down_price)
+      assert_kind_of(Integer, round_down_price)
     end
   end
 end


### PR DESCRIPTION
This PR closes #2 .

Using Ruby built-in Date class may cause inappropriate ratecalculation, since it depends on server's timezone.
This PR fixes it by using [AS::TimeWithZone#localtime](http://api.rubyonrails.org/classes/ActiveSupport/TimeWithZone.html#method-i-localtime) .