### PR TITLE
Update ruby version on ci for latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0']
+        ruby: [3.0, 3.1, 3.2, head]
 
     steps:
       - uses: actions/checkout@v2
@@ -19,9 +19,9 @@ jobs:
         # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
         # change this to (see https://github.com/ruby/setup-ruby#versioning):
         # uses: ruby/setup-ruby@v1
-        uses: ruby/setup-ruby@v1.75.0
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby-version }}
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Run tests
         run: bundle exec rake

--- a/lib/shouhizei.rb
+++ b/lib/shouhizei.rb
@@ -33,6 +33,6 @@ module Shouhizei
   private
 
   def self.rate_list
-    @@rate_list ||= YAML.load_file(File.expand_path('./../rate_list.yml', __FILE__))
+    @@rate_list ||= YAML.safe_load_file(File.expand_path('./../rate_list.yml', __FILE__), permitted_classes: [Date])
   end
 end


### PR DESCRIPTION
There is breaking change for Psych(=YAML).
shouhizei cut the support for Ruby 2.7

refs:
https://www.docswell.com/s/pink_bangbi/K67RV5-2022-01-06-201330#p19
https://github.com/ruby/psych/issues/489There is breaking change for Psych(=YAML).
